### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/py-evm/security/code-scanning/1](https://github.com/Dargon789/py-evm/security/code-scanning/1)

To fix the problem, explicitly set restricted `GITHUB_TOKEN` permissions in the workflow, following the principle of least privilege. Since this workflow only checks out code and runs local tools (conda, flake8, pytest) without modifying GitHub resources, the job only needs `contents: read`. You can define this at the workflow root so it applies to all jobs (currently only `build-linux`), and override later per job if required.

The best fix with minimal functional change is:

- Add a `permissions:` block at the top level of `.github/workflows/python-package-conda.yml`, between the `on:` block and the `jobs:` block.
- Set `contents: read` in that block. This allows `actions/checkout@v4` to function while removing unnecessary write privileges from the default token.
- No other imports, methods, or definitions are needed, because this is purely a YAML workflow configuration change.

Concretely, in `.github/workflows/python-package-conda.yml`, insert:

```yml
permissions:
  contents: read
```

after the `on:` section (after line 9 and before line 11 in the provided snippet).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Build:
- Set workflow-level GITHUB_TOKEN permissions to read-only contents in python-package-conda CI configuration to address code scanning permissions alert.